### PR TITLE
Changes needed for QML.jl 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 ModernGL = "66fc600b-dfda-50eb-8b99-91cfa97b1301"
 QML = "2db162a6-7e43-52c3-8d84-290c1c42d82a"
-jlqml_jll = "6b5019fb-a83d-5b4e-a9f7-678a36c28df7"
 
 [compat]
 Makie = "0.17"
+QML = "0.10"

--- a/src/QMLMakie.jl
+++ b/src/QMLMakie.jl
@@ -1,7 +1,5 @@
 module QMLMakie
 
-import jlqml_jll
-
 using GLMakie
 using CxxWrap
 using QML
@@ -13,10 +11,8 @@ using LinearAlgebra
 const enable_SSAO = Ref(false)
 const enable_FXAA = Ref(true)
 
-@wrapmodule jlqml_jll.get_libjlqml_path :define_julia_module_makie
-
 function __init__()
-  @initcxx
+  QML.define_julia_module_makie(QMLMakie)
 end
 
 mutable struct QMLGLContext
@@ -238,4 +234,4 @@ function on_context_destroy()
   return
 end
 
-end # module QtMakie
+end # module QMLMakie


### PR DESCRIPTION
This includes a few changes needed for the upcoming QML 0.10, which will only support Makie through use of the QMLMakie package.

We will also need to decide where to host this, I think it's fine to keep it here, but in that case I would like to get merge access, since I intend to take a look at moving to a more recent Makie next.